### PR TITLE
登録処理に関する例外処理及びバリデーション実装

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,28 +1,29 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.2.4'
-	id 'io.spring.dependency-management' version '1.1.4'
+    id 'java'
+    id 'org.springframework.boot' version '3.2.4'
+    id 'io.spring.dependency-management' version '1.1.4'
 }
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '17'
+    sourceCompatibility = '17'
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.3'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.3'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.3'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.3'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/sql/001-create-table-and-load-data.sql
+++ b/sql/001-create-table-and-load-data.sql
@@ -2,7 +2,7 @@ DROP TABLE IF EXISTS lures;
 
 CREATE TABLE lures (
   id int unsigned AUTO_INCREMENT,
-  product VARCHAR(100) NOT NULL,
+  product VARCHAR(100) NOT NULL UNIQUE,
   company VARCHAR(100) NOT NULL,
   size double NOT NULL,
   weight double NOT NULL,

--- a/src/main/java/com/example/lures/CustomExceptionHandler.java
+++ b/src/main/java/com/example/lures/CustomExceptionHandler.java
@@ -3,10 +3,14 @@ package com.example.lures;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @RestControllerAdvice
@@ -24,4 +28,55 @@ public class CustomExceptionHandler {
         return new ResponseEntity(body, HttpStatus.NOT_FOUND);
     }
 
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        List<Map<String, String>> errors = new ArrayList<>();
+        e.getBindingResult().getFieldErrors().forEach(fieldError -> {
+            Map<String, String> error = new HashMap<>();
+            error.put("field", fieldError.getField());
+            error.put("message", fieldError.getDefaultMessage());
+            errors.add(error);
+        });
+        ErrorResponse errorResponse = new ErrorResponse(HttpStatus.BAD_REQUEST, "validation error", errors);
+        return ResponseEntity.badRequest().body(errorResponse);
+    }
+
+    public static final class ErrorResponse {
+        private final HttpStatus status;
+        private final String message;
+        private final List<Map<String, String>> errors;
+
+        public ErrorResponse(HttpStatus status, String message, List<Map<String, String>> errors) {
+            this.status = status;
+            this.message = message;
+            this.errors = errors;
+        }
+
+        public HttpStatus getStatus() {
+            return status;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        public List<Map<String, String>> getErrors() {
+            return errors;
+        }
+
+    }
+
+    @ExceptionHandler(value = LureDuplicatedException.class)
+    public ResponseEntity<Map<String, String>> handleLureDuplicatedException(
+            LureDuplicatedException e, HttpServletRequest request) {
+        Map<String, String> body = Map.of(
+                "timestamp", ZonedDateTime.now().toString(),
+                "status", String.valueOf(HttpStatus.BAD_REQUEST.value()),
+                "error", HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                "message", e.getMessage(),
+                "path", request.getRequestURI());
+        return new ResponseEntity(body, HttpStatus.BAD_REQUEST);
+    }
 }
+
+

--- a/src/main/java/com/example/lures/LureController.java
+++ b/src/main/java/com/example/lures/LureController.java
@@ -1,6 +1,7 @@
 package com.example.lures;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -32,7 +33,7 @@ public class LureController {
     }
 
     @PostMapping("/lures")
-    public ResponseEntity<LureResponse> insert(@RequestBody LureRequest lureRequest, UriComponentsBuilder uriBuilder) {
+    public ResponseEntity<LureResponse> insert(@RequestBody @Validated LureRequest lureRequest, UriComponentsBuilder uriBuilder) {
         Lure lure = lureService.insert(lureRequest.getProduct(), lureRequest.getCompany(), lureRequest.getSize(), lureRequest.getWeight());
         URI location = uriBuilder.path("/lures/{id}").buildAndExpand(lure.getId()).toUri();
         LureResponse body = new LureResponse("created");

--- a/src/main/java/com/example/lures/LureDuplicatedException.java
+++ b/src/main/java/com/example/lures/LureDuplicatedException.java
@@ -1,0 +1,8 @@
+package com.example.lures;
+
+public class LureDuplicatedException extends RuntimeException {
+
+    public LureDuplicatedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/lures/LureMapper.java
+++ b/src/main/java/com/example/lures/LureMapper.java
@@ -23,4 +23,8 @@ public interface LureMapper {
     @Insert("INSERT INTO lures (product, company, size, weight) VALUES (#{product}, #{company}, #{size}, #{weight})")
     @Options(useGeneratedKeys = true, keyProperty = "id")
     void insert(Lure lure);
+
+    @Select("SELECT * FROM lures WHERE product = #{product}")
+    List<Lure> diplicatedLure(String product);
+
 }

--- a/src/main/java/com/example/lures/LureMapper.java
+++ b/src/main/java/com/example/lures/LureMapper.java
@@ -25,6 +25,6 @@ public interface LureMapper {
     void insert(Lure lure);
 
     @Select("SELECT * FROM lures WHERE product = #{product}")
-    List<Lure> diplicatedLure(String product);
+    List<Lure> findByLure(String product);
 
 }

--- a/src/main/java/com/example/lures/LureRequest.java
+++ b/src/main/java/com/example/lures/LureRequest.java
@@ -1,15 +1,22 @@
 package com.example.lures;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+
 public class LureRequest {
 
     private Integer id;
 
+    @NotBlank
     private String product;
 
+    @NotBlank
     private String company;
 
+    @Positive
     private double size;
 
+    @Positive
     private double weight;
 
     public LureRequest(Integer id, String product, String company, double size, double weight) {

--- a/src/main/java/com/example/lures/LureService.java
+++ b/src/main/java/com/example/lures/LureService.java
@@ -27,12 +27,6 @@ public class LureService {
         return lure.orElseThrow(() -> new LureNotFoundException("lure not found"));
     }
 
-//    public Lure insert(String product, String company, double size, double weight) {
-//        Lure lure = new Lure(product, company, size, weight);
-//        lureMapper.insert(lure);
-//        return lure;
-//    }
-
     public Lure insert(String product, String company, double size, double weight) {
         Lure lure = new Lure(product, company, size, weight);
         if (!lureMapper.diplicatedLure(product).isEmpty()) {

--- a/src/main/java/com/example/lures/LureService.java
+++ b/src/main/java/com/example/lures/LureService.java
@@ -27,8 +27,17 @@ public class LureService {
         return lure.orElseThrow(() -> new LureNotFoundException("lure not found"));
     }
 
+//    public Lure insert(String product, String company, double size, double weight) {
+//        Lure lure = new Lure(product, company, size, weight);
+//        lureMapper.insert(lure);
+//        return lure;
+//    }
+
     public Lure insert(String product, String company, double size, double weight) {
         Lure lure = new Lure(product, company, size, weight);
+        if (!lureMapper.diplicatedLure(product).isEmpty()) {
+            throw new LureDuplicatedException("There is duplicated data!");
+        }
         lureMapper.insert(lure);
         return lure;
     }

--- a/src/main/java/com/example/lures/LureService.java
+++ b/src/main/java/com/example/lures/LureService.java
@@ -29,7 +29,7 @@ public class LureService {
 
     public Lure insert(String product, String company, double size, double weight) {
         Lure lure = new Lure(product, company, size, weight);
-        if (!lureMapper.diplicatedLure(product).isEmpty()) {
+        if (!lureMapper.findByLure(product).isEmpty()) {
             throw new LureDuplicatedException("There is duplicated data!");
         }
         lureMapper.insert(lure);


### PR DESCRIPTION
## 概要

最終課題として**CRUD機能**を持ったAPIを作成します。

釣りのルアーを`製品名（product）` `メーカー（company）` `長さ（size）` `重さ（weight）`の情報をIDで管理しています。

今回は、登録処理に関する例外処理及びバリデーションの実装を行いました。

## 実装内容

1. `product` `company` を**空欄**また**Null**で送信した場合 → ステータスコード`400`でレスポンス  
2. `size` `weight` を**負数**または**０**で送信した場合  → ステータスコード`400`でレスポンス   
3. 登録する製品が**重複**していた場合 → ステータスコード`400`をレスポンス  
## 実装箇所

- `build.gradle`

- `LureController.java`

- `LureMapper.java`

- `LureRequest.java`

- `LureService.java`

- `CustomExceptionHandler.java`

- `LureDuplicatedException.java`

- `create-table-and-load-data.sql`

## 動作確認

**テーブル** ` id1~id4`のデータが格納されています。

![登録処理前](https://github.com/MasatoKihara25/last-assignment/assets/162205053/a867c3d8-f543-4498-9b48-4c58e4aa72f2)
---


`製品名（product）` `メーカー（company）`が空欄


![製品及びメーカー空欄png](https://github.com/MasatoKihara25/last-assignment/assets/162205053/eec22578-36f8-4718-bebf-ac8b63a942dd)
---


`製品名（product）` `メーカー（company）`がNull


![製品名及びメーカーがNULL](https://github.com/MasatoKihara25/last-assignment/assets/162205053/bf5ff795-f441-49d0-a57f-50018c14ca0f)
---


 `長さ（size）` `重さ（weight）`が０


![重さ及び長さが０](https://github.com/MasatoKihara25/last-assignment/assets/162205053/31d220a6-e6f9-49fa-a4e6-fc6a6b1afa77)
---


`長さ（size）` `重さ（weight）`がNull


![重さ及び長さがNULL](https://github.com/MasatoKihara25/last-assignment/assets/162205053/3546cc6f-3abf-4708-bc27-5d8a8283bfbb)
---


登録した`製品名（product）`がテーブル内のデータと重複していた場合


![重複した製品名で登録](https://github.com/MasatoKihara25/last-assignment/assets/162205053/1fd6e708-e775-4ef5-918f-abb4e8ae46d9)


