### PR TITLE
更新処理の実装【更新機能／例外処理／バリデーションの追加】

### DIFF
--- a/src/main/java/com/example/lures/CustomExceptionHandler.java
+++ b/src/main/java/com/example/lures/CustomExceptionHandler.java
@@ -7,7 +7,6 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import java.sql.SQLIntegrityConstraintViolationException;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -72,22 +71,10 @@ public class CustomExceptionHandler {
             LureDuplicatedException e, HttpServletRequest request) {
         Map<String, String> body = Map.of(
                 "timestamp", ZonedDateTime.now().toString(),
-                "status", String.valueOf(HttpStatus.BAD_REQUEST.value()),
-                "error", HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                "status", String.valueOf(HttpStatus.CONFLICT.value()),
+                "error", HttpStatus.CONFLICT.getReasonPhrase(),
                 "message", e.getMessage(),
                 "path", request.getRequestURI());
-        return new ResponseEntity(body, HttpStatus.BAD_REQUEST);
-    }
-
-    @ExceptionHandler(SQLIntegrityConstraintViolationException.class)
-    public ResponseEntity<ErrorResponse> handleSQLIntegrityConstraintViolationException(SQLIntegrityConstraintViolationException e) {
-        List<Map<String, String>> errors = new ArrayList<>();
-        Map<String, String> error = new HashMap<>();
-        error.put("message", "そのルアーは他のIDで登録されています");
-        errors.add(error);
-        ErrorResponse errorResponse = new ErrorResponse(HttpStatus.CONFLICT, "Duplicate entry", errors);
-        return ResponseEntity.status(HttpStatus.CONFLICT).body(errorResponse);
+        return new ResponseEntity(body, HttpStatus.CONFLICT);
     }
 }
-
-

--- a/src/main/java/com/example/lures/CustomExceptionHandler.java
+++ b/src/main/java/com/example/lures/CustomExceptionHandler.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.sql.SQLIntegrityConstraintViolationException;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -76,6 +77,16 @@ public class CustomExceptionHandler {
                 "message", e.getMessage(),
                 "path", request.getRequestURI());
         return new ResponseEntity(body, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(SQLIntegrityConstraintViolationException.class)
+    public ResponseEntity<ErrorResponse> handleSQLIntegrityConstraintViolationException(SQLIntegrityConstraintViolationException e) {
+        List<Map<String, String>> errors = new ArrayList<>();
+        Map<String, String> error = new HashMap<>();
+        error.put("message", "そのルアーは他のIDで登録されています");
+        errors.add(error);
+        ErrorResponse errorResponse = new ErrorResponse(HttpStatus.CONFLICT, "Duplicate entry", errors);
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(errorResponse);
     }
 }
 

--- a/src/main/java/com/example/lures/Lure.java
+++ b/src/main/java/com/example/lures/Lure.java
@@ -47,4 +47,24 @@ public class Lure {
     public double getWeight() {
         return weight;
     }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public void setProduct(String product) {
+        this.product = product;
+    }
+
+    public void setCompany(String company) {
+        this.company = company;
+    }
+
+    public void setSize(double size) {
+        this.size = size;
+    }
+
+    public void setWeight(double weight) {
+        this.weight = weight;
+    }
 }

--- a/src/main/java/com/example/lures/LureController.java
+++ b/src/main/java/com/example/lures/LureController.java
@@ -3,6 +3,7 @@ package com.example.lures;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -38,5 +39,12 @@ public class LureController {
         URI location = uriBuilder.path("/lures/{id}").buildAndExpand(lure.getId()).toUri();
         LureResponse body = new LureResponse("created");
         return ResponseEntity.created(location).body(body);
+    }
+
+    @PatchMapping("/lures/{id}")
+    public ResponseEntity<LureResponse> update(@PathVariable("id") Integer id, @RequestBody @Validated LureRequest lureRequest) {
+        Lure lure = lureService.update(id, lureRequest.getProduct(), lureRequest.getCompany(), lureRequest.getSize(), lureRequest.getWeight());
+        LureResponse body = new LureResponse("Lure updated");
+        return ResponseEntity.ok(body);
     }
 }

--- a/src/main/java/com/example/lures/LureMapper.java
+++ b/src/main/java/com/example/lures/LureMapper.java
@@ -26,7 +26,8 @@ public interface LureMapper {
     void insert(Lure lure);
 
     @Select("SELECT * FROM lures WHERE product = #{product}")
-    List<Lure> findByLure(String product);
+    Optional<Lure> findByLure(String product);
+
 
     @Update("UPDATE lures SET product = #{product}, company = #{company}, size = #{size}, weight = #{weight} WHERE id = #{id}")
     void update(Lure lure);

--- a/src/main/java/com/example/lures/LureMapper.java
+++ b/src/main/java/com/example/lures/LureMapper.java
@@ -4,6 +4,7 @@ import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Options;
 import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
 
 import java.util.List;
 import java.util.Optional;
@@ -27,4 +28,6 @@ public interface LureMapper {
     @Select("SELECT * FROM lures WHERE product = #{product}")
     List<Lure> findByLure(String product);
 
+    @Update("UPDATE lures SET product = #{product}, company = #{company}, size = #{size}, weight = #{weight} WHERE id = #{id}")
+    void update(Lure lure);
 }

--- a/src/main/java/com/example/lures/LureService.java
+++ b/src/main/java/com/example/lures/LureService.java
@@ -40,6 +40,12 @@ public class LureService {
         Optional<Lure> optionalLure = this.lureMapper.findById(id);
         Lure lure = optionalLure.orElseThrow(() -> new LureNotFoundException("Lure not found"));
 
+        if (lure.getProduct().equals(product)) {
+            return lure;
+        } else if (!lureMapper.findByLure(product).isEmpty()) {
+            throw new LureDuplicatedException("There is duplicated data!");
+        }
+
         lure.setProduct(product);
         lure.setCompany(company);
         lure.setSize(size);

--- a/src/main/java/com/example/lures/LureService.java
+++ b/src/main/java/com/example/lures/LureService.java
@@ -41,7 +41,7 @@ public class LureService {
         Lure lure = optionalLure.orElseThrow(() -> new LureNotFoundException("Lure not found"));
 
         Optional<Lure> existingLure = lureMapper.findByLure(product);
-        if (!existingLure.isEmpty() && !existingLure.stream().anyMatch(l -> l.getId().equals(id))) {
+        if (existingLure.isPresent() && existingLure.stream().noneMatch(l -> l.getId().equals(id))) {
             throw new LureDuplicatedException("There is duplicated data!");
         }
 

--- a/src/main/java/com/example/lures/LureService.java
+++ b/src/main/java/com/example/lures/LureService.java
@@ -40,8 +40,8 @@ public class LureService {
         Optional<Lure> optionalLure = this.lureMapper.findById(id);
         Lure lure = optionalLure.orElseThrow(() -> new LureNotFoundException("Lure not found"));
 
-        List<Lure> existingLureId = lureMapper.findByLure(product);
-        if (!existingLureId.isEmpty() && !existingLureId.stream().anyMatch(l -> l.getId().equals(id))) {
+        Optional<Lure> existingLure = lureMapper.findByLure(product);
+        if (!existingLure.isEmpty() && !existingLure.stream().anyMatch(l -> l.getId().equals(id))) {
             throw new LureDuplicatedException("There is duplicated data!");
         }
 

--- a/src/main/java/com/example/lures/LureService.java
+++ b/src/main/java/com/example/lures/LureService.java
@@ -35,4 +35,17 @@ public class LureService {
         lureMapper.insert(lure);
         return lure;
     }
+
+    public Lure update(Integer id, String product, String company, double size, double weight) {
+        Optional<Lure> optionalLure = this.lureMapper.findById(id);
+        Lure lure = optionalLure.orElseThrow(() -> new LureNotFoundException("Lure not found"));
+
+        lure.setProduct(product);
+        lure.setCompany(company);
+        lure.setSize(size);
+        lure.setWeight(weight);
+
+        lureMapper.update(lure);
+        return lure;
+    }
 }

--- a/src/main/java/com/example/lures/LureService.java
+++ b/src/main/java/com/example/lures/LureService.java
@@ -40,9 +40,8 @@ public class LureService {
         Optional<Lure> optionalLure = this.lureMapper.findById(id);
         Lure lure = optionalLure.orElseThrow(() -> new LureNotFoundException("Lure not found"));
 
-        if (lure.getProduct().equals(product)) {
-            return lure;
-        } else if (!lureMapper.findByLure(product).isEmpty()) {
+        List<Lure> existingLureId = lureMapper.findByLure(product);
+        if (!existingLureId.isEmpty() && !existingLureId.stream().anyMatch(l -> l.getId().equals(id))) {
             throw new LureDuplicatedException("There is duplicated data!");
         }
 


### PR DESCRIPTION
## 概要

最終課題として**CRUD機能**を持ったAPIを作成します。

釣りのルアーを`製品名（product）` `メーカー（company）` `長さ（size）` `重さ（weight）`の情報をIDで管理しています。

今回は、**更新処理**、更新処理に関する**例外処理**及び**バリデーションの追加**を実装しました。

## 実装箇所

- `LureController.java`

- `lures/LureService.java`

- `LureMapper.java`

- `Lure.java`

- `CustomExceptionHandler.java`

## 動作確認


**テーブル**　`id1~id4`が格納されています。赤枠の`id4`の更新処理を実行します。


![更新前](https://github.com/MasatoKihara25/last-assignment/assets/162205053/7465399d-daea-4603-ad7f-70e40cb514dd)


**更新処理を実施**  


- `JSON型`でリクエストボディを送信

- ステータスコード `200` かつ更新処理が成功したことを伝える` OK `をレスポンス


![更新処理](https://github.com/MasatoKihara25/last-assignment/assets/162205053/3c9f669e-dbbf-4143-91e2-0f37f21502ce)


- 更新後のテーブルは以下のとおり。


![更新処理実施後](https://github.com/MasatoKihara25/last-assignment/assets/162205053/27302008-f9eb-405b-b770-d8f7d1b64fbd)

----

**例外処理**


- `ID`が存在しない場合はステータスコード`404`及びデータが存在しないことを伝える`Not Found`をレスポンス


![idが存在しない場合](https://github.com/MasatoKihara25/last-assignment/assets/162205053/06e8e098-c2b7-4bc8-8bb9-873123dceaaa)


- 更新した`製品名（product）`が重複していた場合はステータスコード`409`及び重複を伝える`Conflict`をレスポンス


![他のIDの時はコンフリクトを返す](https://github.com/MasatoKihara25/last-assignment/assets/162205053/37f2863a-a98d-4dc4-93bf-3f634f46d80d)


- 同様のIDのデータの場合、`製品名（product）`が重複していても更新処理を実施できるように実装


![IDが同じの場合](https://github.com/MasatoKihara25/last-assignment/assets/162205053/f083a496-9551-4fc0-8ab0-f640099ca2a6)


- `製品名（product）`をそのままで他のカラムを変更し更新をかけられるように実装


![同様のIDで他のカラムを修正](https://github.com/MasatoKihara25/last-assignment/assets/162205053/9ba9cb0c-05f8-41e0-958e-497ab8fd4acf)


- 修正後のデータは以下のとおり。


![修正後](https://github.com/MasatoKihara25/last-assignment/assets/162205053/aa96c722-b794-478b-9902-09c386e1f3a9)



----

**バリデーションの実装**



- `製品名（product）` `メーカー（company）` が空欄の場合

-  `長さ（size）` `重さ（weight）`が**０**の場合


![バリデーションによる処理400](https://github.com/MasatoKihara25/last-assignment/assets/162205053/c18f9122-fe58-42ef-bfad-fe3e196719dd)



- `製品名（product）` `メーカー（company）` が**null**の場合

-  `長さ（size）` `重さ（weight）`が**負数**の場合



![null及び負数](https://github.com/MasatoKihara25/last-assignment/assets/162205053/02ca785e-2e18-4622-8bc3-c281a63fcaf5)

