### PR TITLE
LureService.javaの作成(READ処理テストの作成)

### DIFF
--- a/src/main/java/com/example/lures/Lure.java
+++ b/src/main/java/com/example/lures/Lure.java
@@ -1,5 +1,7 @@
 package com.example.lures;
 
+import java.util.Objects;
+
 public class Lure {
 
     private Integer id;
@@ -66,5 +68,22 @@ public class Lure {
 
     public void setWeight(double weight) {
         this.weight = weight;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Lure lure = (Lure) o;
+        return Objects.equals(id, lure.id) &&
+                Objects.equals(product, lure.product) &&
+                Objects.equals(company, lure.company) &&
+                Objects.equals(size, lure.size) &&
+                Objects.equals(weight, lure.weight);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, product, company, size, weight);
     }
 }

--- a/src/main/java/com/example/lures/LureService.java
+++ b/src/main/java/com/example/lures/LureService.java
@@ -60,4 +60,5 @@ public class LureService {
         lureMapper.delete(lure);
         return lure;
     }
+
 }

--- a/src/test/java/com/example/lures/LureServiceTest.java
+++ b/src/test/java/com/example/lures/LureServiceTest.java
@@ -34,7 +34,7 @@ class LureServiceTest {
     }
 
     @Test
-    public void URLにクエリ文字列を指定した場合に指定したクエリ文字列を含むルアーが返されること() {
+    public void 引数に指定した文字列を含むルアーの情報が返されること() {
         List<Lure> expectedLure = List.of(new Lure(1, "Balaam300", "Madness", 300, 168));
         doReturn(expectedLure).when(lureMapper).findLures("B");
         List<Lure> actual = lureService.findLure("B");

--- a/src/test/java/com/example/lures/LureServiceTest.java
+++ b/src/test/java/com/example/lures/LureServiceTest.java
@@ -1,0 +1,54 @@
+package com.example.lures;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class LureServiceTest {
+    @InjectMocks
+    LureService lureService;
+    @Mock
+    LureMapper lureMapper;
+
+    @Test
+    public void 存在するルアーを全件取得すること() {
+        List<Lure> lureList = List.of(
+                new Lure(1, "Balaam300", "Madness", 300, 168),
+                new Lure(2, "JointedCRAW178", "GANCRAFT", 178, 56));
+        doReturn(lureList).when(lureMapper).findAll();
+        List<Lure> actual = lureService.findLure((String) null);
+        assertThat(actual).isEqualTo(lureList);
+        verify(lureMapper, times(1)).findAll();
+    }
+
+    @Test
+    public void URLにクエリ文字列を指定した場合に指定したクエリ文字列を含むルアーが返されること() {
+        List<Lure> expectedLure = List.of(new Lure(1, "Balaam300", "Madness", 300, 168));
+        doReturn(expectedLure).when(lureMapper).findLures("B");
+        List<Lure> actual = lureService.findLure("B");
+        assertThat(actual).isEqualTo(expectedLure);
+        verify(lureMapper, times(1)).findLures("B");
+    }
+
+    @Test
+    public void 存在しないルアーのIDを指定した場合にエラーが返されること() {
+        doReturn(Optional.empty()).when(lureMapper).findById(99);
+        assertThatThrownBy(() -> {
+            lureService.findLure(99);
+        }).isInstanceOf(LureNotFoundException.class);
+        verify(lureMapper, times(1)).findById(99);
+    }
+
+}

--- a/src/test/java/com/example/lures/LureServiceTest.java
+++ b/src/test/java/com/example/lures/LureServiceTest.java
@@ -43,6 +43,14 @@ class LureServiceTest {
     }
 
     @Test
+    public void 存在するルアーのIDを指定した場合に該当するルアーが返されること() {
+        doReturn(Optional.of(new Lure(1, "Balaam300", "Madness", 300, 168))).when(lureMapper).findById(1);
+        Lure actual = lureService.findLure(1);
+        assertThat(actual).isEqualTo(new Lure(1, "Balaam300", "Madness", 300, 168));
+        verify(lureMapper, times(1)).findById(1);
+    }
+
+    @Test
     public void 存在しないルアーのIDを指定した場合にエラーが返されること() {
         doReturn(Optional.empty()).when(lureMapper).findById(99);
         assertThatThrownBy(() -> {
@@ -50,5 +58,6 @@ class LureServiceTest {
         }).isInstanceOf(LureNotFoundException.class);
         verify(lureMapper, times(1)).findById(99);
     }
+
 
 }


### PR DESCRIPTION
## 概要

最終課題として**CRUD機能**を持ったAPIを作成します。

釣りのルアーを`製品名（product）` `メーカー（company）` `長さ（size）` `重さ（weight）`の情報をIDで管理しています。

今回は、**READ処理**の**テストコード**を実装しました。

----

## 実装箇所


- `Lure.java`

- `lures/LureServiceTest.java`

----

## 動作確認


- `テーブル内に存在するルアーを全件取得する場合`



![全件取得](https://github.com/MasatoKihara25/last-assignment/assets/162205053/2c76a7da-cc22-433e-af35-17eb5efce88c)



- `URLにクエリ文字列を指定した場合された場合`



![クエリ文字列](https://github.com/MasatoKihara25/last-assignment/assets/162205053/7aca8dd3-508e-46af-8b9e-bdb1bbc53996)



- `IDよる検索が実施された場合`



![ID検索](https://github.com/MasatoKihara25/last-assignment/assets/162205053/161043ed-029b-41f4-80d3-4e0949f12765)



- `存在しないIDが検索された場合`



![存在しないID](https://github.com/MasatoKihara25/last-assignment/assets/162205053/cd09ec8c-b3bb-413e-82bf-abb559800602)


