### PR TITLE
登録、更新及び削除処理に関するテストコード作成

### DIFF
--- a/src/test/java/com/example/lures/LureServiceTest.java
+++ b/src/test/java/com/example/lures/LureServiceTest.java
@@ -11,6 +11,8 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -59,5 +61,74 @@ class LureServiceTest {
         verify(lureMapper, times(1)).findById(99);
     }
 
+    @Test
+    public void 新しいルアーを登録すること() {
+
+        doReturn(Optional.empty()).when(lureMapper).findByLure("Balaam300");
+        Lure actual = lureService.insert("Balaam300", "Madness", 300, 168);
+
+        assertNotNull(actual);
+        assertThat(actual).isEqualTo(new Lure("Balaam300", "Madness", 300, 168));
+        verify(lureMapper, times(1)).insert(any(Lure.class));
+    }
+
+    @Test
+    public void 新しいルアーを登録する時に製品名の重複がある場合は例外処理が返されること() {
+
+        doReturn(Optional.of(new Lure("Balaam300", "Madness", 300, 168))).when(lureMapper).findByLure("Balaam300");
+
+        assertThatThrownBy(() -> {
+            lureService.insert("Balaam300", "Madness", 300, 168);
+        }).isInstanceOf(LureDuplicatedException.class);
+        verify(lureMapper, times(1)).findByLure("Balaam300");
+    }
+
+    @Test
+    public void 既存のルアーを更新すること() {
+
+        Lure lure = new Lure(1, "Balaam300", "Madness", 300, 168);
+        doReturn(Optional.of(lure)).when(lureMapper).findById(1);
+        doReturn(Optional.empty()).when(lureMapper).findByLure("Balaam300");
+
+        Lure actual = lureService.update(1, "Balaam300", "Madness", 300, 168);
+
+        assertNotNull(actual);
+        assertThat(actual).isEqualTo(new Lure(1, "Balaam300", "Madness", 300, 168));
+        verify(lureMapper).update(lure);
+    }
+
+    @Test
+    public void ルアーを更新する時に指定したIDが見つからないこと() {
+
+        doReturn(Optional.empty()).when(lureMapper).findById(99);
+
+        assertThatThrownBy(() -> {
+            lureService.update(99, "Balaam300", "Madness", 300, 168);
+        }).isInstanceOf(LureNotFoundException.class);
+    }
+
+    @Test
+    public void ルアーを更新する時に製品名が重複していること() {
+
+        Lure updatingMusic = new Lure(1, "Balaam300", "Madness", 300, 168);
+        doReturn(Optional.of(updatingMusic)).when(lureMapper).findById(1);
+
+        Lure duplicatedLure = new Lure(2, "Balaam300", "Madness", 300, 168);
+        doReturn(Optional.of(duplicatedLure)).when(lureMapper).findByLure("Balaam300");
+
+        assertThatThrownBy(() -> {
+            lureService.update(1, "Balaam300", "Madness", 300, 168);
+        }).isInstanceOf(LureDuplicatedException.class);
+    }
+
+    @Test
+    public void IDを指定して楽曲を削除すること() {
+        Lure lure = new Lure(1, "Balaam300", "Madness", 300, 168);
+        doReturn(Optional.of(lure)).when(lureMapper).findById(1);
+
+        Lure actual = lureService.delete(1);
+
+        assertThat(actual).isEqualTo(new Lure(1, "Balaam300", "Madness", 300, 168));
+    }
 
 }

--- a/src/test/java/com/example/lures/LureServiceTest.java
+++ b/src/test/java/com/example/lures/LureServiceTest.java
@@ -62,7 +62,7 @@ class LureServiceTest {
     }
 
     @Test
-    public void 新しいルアーを登録すること() {
+    public void 新しいルアーを登録できること() {
 
         doReturn(Optional.empty()).when(lureMapper).findByLure("Balaam300");
         Lure actual = lureService.insert("Balaam300", "Madness", 300, 168);
@@ -73,7 +73,7 @@ class LureServiceTest {
     }
 
     @Test
-    public void 新しいルアーを登録する時に製品名の重複がある場合は例外処理が返されること() {
+    public void 新しいルアーを登録する時に製品名の重複がある場合は例外をスローすること() {
 
         doReturn(Optional.of(new Lure("Balaam300", "Madness", 300, 168))).when(lureMapper).findByLure("Balaam300");
 
@@ -84,7 +84,7 @@ class LureServiceTest {
     }
 
     @Test
-    public void 既存のルアーを更新すること() {
+    public void 既存のルアーを更新できること() {
 
         Lure lure = new Lure(1, "Balaam300", "Madness", 300, 168);
         doReturn(Optional.of(lure)).when(lureMapper).findById(1);
@@ -98,7 +98,7 @@ class LureServiceTest {
     }
 
     @Test
-    public void ルアーを更新する時に指定したIDが見つからないこと() {
+    public void ルアーを更新する時に指定したIDが見つからない場合は例外をスローすること() {
 
         doReturn(Optional.empty()).when(lureMapper).findById(99);
 
@@ -108,7 +108,7 @@ class LureServiceTest {
     }
 
     @Test
-    public void ルアーを更新する時に製品名が重複していること() {
+    public void ルアーを更新する時に製品名が重複している場合は例外をスローすること() {
 
         Lure updatingMusic = new Lure(1, "Balaam300", "Madness", 300, 168);
         doReturn(Optional.of(updatingMusic)).when(lureMapper).findById(1);
@@ -122,7 +122,7 @@ class LureServiceTest {
     }
 
     @Test
-    public void IDを指定して楽曲を削除すること() {
+    public void IDを指定してルアーを削除できること() {
         Lure lure = new Lure(1, "Balaam300", "Madness", 300, 168);
         doReturn(Optional.of(lure)).when(lureMapper).findById(1);
 


### PR DESCRIPTION
## 概要

最終課題として**CRUD機能**を持ったAPIを作成します。

釣りのルアーを`製品名（product）` `メーカー（company）` `長さ（size）` `重さ（weight）`の情報をIDで管理しています。

今回は、**登録処理**、**更新処理**及び**削除処理**の**テストコード**を実装しました。

----

## 実装箇所


- `lures/LureServiceTest.java`

----

## 動作確認



- `新規登録する場合`



![新規登録](https://github.com/MasatoKihara25/last-assignment/assets/162205053/d8752dd1-9181-406a-a897-0551484588ae)




- `新規登録時に製品名に重複があった場合`



![新規登録【重複】](https://github.com/MasatoKihara25/last-assignment/assets/162205053/e435d035-4def-46f8-99d0-95ec2e166213)



- `既存のルアーを更新する場合`



![更新処理](https://github.com/MasatoKihara25/last-assignment/assets/162205053/8fef7b19-9ff0-4906-8978-56ddf267bfc5)



- `既存のルアーを更新する時に製品名の重複があった場合`



![ID重複【更新処理】](https://github.com/MasatoKihara25/last-assignment/assets/162205053/5a872e96-4e61-4636-abdc-db59ba4d47a5)



- `既存のルアーを更新する時にIDが見つからなかった場合`



![ID未発見【更新処理】](https://github.com/MasatoKihara25/last-assignment/assets/162205053/dc1dae39-6854-4ffe-847a-6e3e3f17065a)



- `既存のルアーを削除する場合`



![削除処理](https://github.com/MasatoKihara25/last-assignment/assets/162205053/d984f71d-b835-4d1a-9e24-b0af8339cc82)