### PR TITLE
DBテストの実装【lureMapperTest.javaの作成】

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.3'
+    testImplementation 'com.github.database-rider:rider-spring:1.42.0'
 }
 
 tasks.named('test') {

--- a/src/test/java/com/example/lures/LureMapperTest.java
+++ b/src/test/java/com/example/lures/LureMapperTest.java
@@ -55,9 +55,9 @@ class LureMapperTest {
     @DataSet(value = "datasets/lures.yml")
     @Transactional
     public void 存在するIDを指定した場合に該当するルアーデータが返されること() {
-        Optional<Lure> lureList = lureMapper.findById(1);
+        Optional<Lure> lure = lureMapper.findById(1);
 
-        assertThat(lureList)
+        assertThat(lure)
                 .isPresent()
                 .hasValue(
                         new Lure(1, "Balaam300", "Madness", 300, 168)
@@ -68,9 +68,9 @@ class LureMapperTest {
     @DataSet(value = "datasets/lures.yml")
     @Transactional
     public void 存在しないIDを指定した場合に空のデータが返されること() {
-        Optional<Lure> lureList = lureMapper.findById(5);
+        Optional<Lure> lure = lureMapper.findById(5);
 
-        assertThat(lureList)
+        assertThat(lure)
                 .isEmpty();
     }
 
@@ -81,12 +81,8 @@ class LureMapperTest {
         Lure lure = new Lure("Royal flash", "EVERGREEN", 160, 60);
         lureMapper.insert(lure);
 
-        Optional<Lure> musicList = lureMapper.findById(lure.getId());
-        assertThat(musicList).isPresent();
-        assertThat(musicList.get().getProduct()).isEqualTo("Royal flash");
-        assertThat(musicList.get().getCompany()).isEqualTo("EVERGREEN");
-        assertThat(musicList.get().getSize()).isEqualTo(160);
-        assertThat(musicList.get().getWeight()).isEqualTo(60);
+        Optional<Lure> lureList = lureMapper.findById(lure.getId());
+        assertThat(lureList).isPresent();
     }
 
     @Test
@@ -100,10 +96,6 @@ class LureMapperTest {
 
         Optional<Lure> updatedLure = lureMapper.findById(3);
         assertThat(updatedLure).isPresent();
-        assertThat(updatedLure.get().getProduct()).isEqualTo("SLIDESWIMMER175");
-        assertThat(updatedLure.get().getCompany()).isEqualTo("deps");
-        assertThat(updatedLure.get().getSize()).isEqualTo(175);
-        assertThat(updatedLure.get().getWeight()).isEqualTo(72.8);
     }
 
     @Test

--- a/src/test/java/com/example/lures/LureMapperTest.java
+++ b/src/test/java/com/example/lures/LureMapperTest.java
@@ -1,0 +1,120 @@
+package com.example.lures;
+
+import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.core.api.dataset.ExpectedDataSet;
+import com.github.database.rider.spring.api.DBRider;
+import org.junit.jupiter.api.Test;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DBRider
+@MybatisTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class LureMapperTest {
+
+    @Autowired
+    LureMapper lureMapper;
+
+    @Test
+    @DataSet(value = "datasets/lures.yml")
+    @Transactional
+    public void すべてのルアーデータが取得できること() {
+        List<Lure> lureList = lureMapper.findAll();
+
+        assertThat(lureList)
+                .hasSize(4)
+                .contains(
+                        new Lure(1, "Balaam300", "Madness", 300, 168),
+                        new Lure(2, "JointedCRAW178", "GANCRAFT", 178, 56),
+                        new Lure(3, "SILENTKILLER175", "deps", 175, 70),
+                        new Lure(4, "BULLSHOOTER160", "deps", 160, 98)
+                );
+    }
+
+    @Test
+    @DataSet(value = "datasets/lures.yml")
+    @Transactional
+    public void 引数に指定した文字列を含むルアーデータが返されること() {
+        List<Lure> lureList = lureMapper.findLures("join");
+
+        assertThat(lureList)
+                .hasSize(1)
+                .contains(
+                        new Lure(2, "JointedCRAW178", "GANCRAFT", 178, 56)
+                );
+    }
+
+    @Test
+    @DataSet(value = "datasets/lures.yml")
+    @Transactional
+    public void 存在するIDを指定した場合に該当するルアーデータが返されること() {
+        Optional<Lure> lureList = lureMapper.findById(1);
+
+        assertThat(lureList)
+                .isPresent()
+                .hasValue(
+                        new Lure(1, "Balaam300", "Madness", 300, 168)
+                );
+    }
+
+    @Test
+    @DataSet(value = "datasets/lures.yml")
+    @Transactional
+    public void 存在しないIDを指定した場合に空のデータが返されること() {
+        Optional<Lure> lureList = lureMapper.findById(5);
+
+        assertThat(lureList)
+                .isEmpty();
+    }
+
+    @Test
+    @ExpectedDataSet(value = "datasets/insertLures.yml", ignoreCols = "id")
+    @Transactional
+    public void 新しいルアーデータを登録できること() {
+        Lure lure = new Lure("Royal flash", "EVERGREEN", 160, 60);
+        lureMapper.insert(lure);
+
+        Optional<Lure> musicList = lureMapper.findById(lure.getId());
+        assertThat(musicList).isPresent();
+        assertThat(musicList.get().getProduct()).isEqualTo("Royal flash");
+        assertThat(musicList.get().getCompany()).isEqualTo("EVERGREEN");
+        assertThat(musicList.get().getSize()).isEqualTo(160);
+        assertThat(musicList.get().getWeight()).isEqualTo(60);
+    }
+
+    @Test
+    @DataSet(value = "datasets/lures.yml")
+    @ExpectedDataSet(value = "datasets/updatedLures.yml", ignoreCols = "id")
+    @Transactional
+    public void IDを指定してルアーデータを更新できること() {
+
+        Lure lure = new Lure(3, "SLIDESWIMMER175", "deps", 175, 72.8);
+        lureMapper.update(lure);
+
+        Optional<Lure> updatedLure = lureMapper.findById(3);
+        assertThat(updatedLure).isPresent();
+        assertThat(updatedLure.get().getProduct()).isEqualTo("SLIDESWIMMER175");
+        assertThat(updatedLure.get().getCompany()).isEqualTo("deps");
+        assertThat(updatedLure.get().getSize()).isEqualTo(175);
+        assertThat(updatedLure.get().getWeight()).isEqualTo(72.8);
+    }
+
+    @Test
+    @DataSet(value = "datasets/lures.yml")
+    @ExpectedDataSet(value = "datasets/deletedLures.yml", ignoreCols = "id")
+    @Transactional
+    public void IDを指定してルアーデータを削除できること() {
+        Lure lure = new Lure(4, "BULLSHOOTER160", "deps", 160, 98);
+        lureMapper.delete(lure);
+
+        Optional<Lure> deletedLure = lureMapper.findById(4);
+        assertThat(deletedLure).isEmpty();
+    }
+}

--- a/src/test/resources/datasets/deletedLures.yml
+++ b/src/test/resources/datasets/deletedLures.yml
@@ -1,0 +1,16 @@
+lures:
+  - id: 1
+    product: "Balaam300"
+    company: "Madness"
+    size: 300
+    weight: 168
+  - id: 2
+    product: "JointedCRAW178"
+    company: "GANCRAFT"
+    size: 178
+    weight: 56
+  - id: 3
+    product: "SILENTKILLER175"
+    company: "deps"
+    size: 175
+    weight: 70

--- a/src/test/resources/datasets/insertLures.yml
+++ b/src/test/resources/datasets/insertLures.yml
@@ -1,0 +1,26 @@
+lures:
+  - id: 1
+    product: "Balaam300"
+    company: "Madness"
+    size: 300
+    weight: 168
+  - id: 2
+    product: "JointedCRAW178"
+    company: "GANCRAFT"
+    size: 178
+    weight: 56
+  - id: 3
+    product: "SILENTKILLER175"
+    company: "deps"
+    size: 175
+    weight: 70
+  - id: 4
+    product: "BULLSHOOTER160"
+    company: "deps"
+    size: 160
+    weight: 98
+  - id: 5
+    product: "Royal flash"
+    company: "EVERGREEN"
+    size: 160
+    weight: 60

--- a/src/test/resources/datasets/lures.yml
+++ b/src/test/resources/datasets/lures.yml
@@ -1,0 +1,21 @@
+lures:
+  - id: 1
+    product: "Balaam300"
+    company: "Madness"
+    size: 300
+    weight: 168
+  - id: 2
+    product: "JointedCRAW178"
+    company: "GANCRAFT"
+    size: 178
+    weight: 56
+  - id: 3
+    product: "SILENTKILLER175"
+    company: "deps"
+    size: 175
+    weight: 70
+  - id: 4
+    product: "BULLSHOOTER160"
+    company: "deps"
+    size: 160
+    weight: 98

--- a/src/test/resources/datasets/updatedLures.yml
+++ b/src/test/resources/datasets/updatedLures.yml
@@ -1,0 +1,21 @@
+lures:
+  - id: 1
+    product: "Balaam300"
+    company: "Madness"
+    size: 300
+    weight: 168
+  - id: 2
+    product: "JointedCRAW178"
+    company: "GANCRAFT"
+    size: 178
+    weight: 56
+  - id: 3
+    product: "SLIDESWIMMER175"
+    company: "deps"
+    size: 175
+    weight: 72.8
+  - id: 4
+    product: "BULLSHOOTER160"
+    company: "deps"
+    size: 160
+    weight: 98

--- a/src/test/resources/dbunit.yml
+++ b/src/test/resources/dbunit.yml
@@ -1,0 +1,9 @@
+cacheConnection: false
+cacheTableNames: false
+properties:
+  schema: lures_database
+caseInsensitiveStrategy: LOWERCASE
+connectionConfig:
+  url: jdbc:mysql://localhost:3307/lures_database # MySQLの場合
+  user: lures
+  password: password


### PR DESCRIPTION
## 概要

最終課題として**CRUD機能**を持ったAPIを作成します。

釣りのルアーを`製品名（product）` `メーカー（company）` `長さ（size）` `重さ（weight）`の情報をIDで管理しています。

今回は、**CRUD機能**に関するDBテストを実装しました。

----

## 実装箇所

- `lures/LureMapperTest.java`


- `resources`


----

## 動作確認

![Mapperテスト](https://github.com/MasatoKihara25/last-assignment/assets/162205053/d46c59d8-e073-4ddf-b2d6-59d77803bc7b)

